### PR TITLE
refactor: finetune reuses pretraining trainer

### DIFF
--- a/src/hsh/config.py
+++ b/src/hsh/config.py
@@ -31,15 +31,16 @@ class TrainConfig(BaseModel, frozen=True):
 
 
 class FinetuneConfig(BaseModel, frozen=True):
-    """Finetuning config -- resumes from a pretrained checkpoint."""
+    """Finetuning config -- composes TrainConfig with a base checkpoint.
+
+    Finetuning reuses the pretraining loop; this config just adds
+    the checkpoint path and overrides training defaults.
+    """
 
     base_checkpoint: str = Field(description="Path to pretrained checkpoint")
-    num_steps: int = Field(default=50, gt=0)
-    lr: float = Field(default=1e-4, gt=0)
-    batch_size: int = Field(default=8, gt=0)
-    num_samples: int = Field(default=64, gt=0)
-    output_dir: str = Field(default="./finetune_outputs")
-    seed: int = Field(default=42)
+    train: TrainConfig = Field(
+        default_factory=lambda: TrainConfig(num_steps=50, lr=1e-4, output_dir="./finetune_outputs")
+    )
 
 
 class EvalConfig(BaseModel, frozen=True):

--- a/src/hsh/finetune.py
+++ b/src/hsh/finetune.py
@@ -1,76 +1,28 @@
 """Finetune from a pretrained checkpoint.
 
-Mirrors hooke-forge's finetuning pattern:
-- Load model + optimizer from checkpoint
-- Optionally override learning rate
-- Continue training for N more steps
-- Save new checkpoint
+Thin wrapper around ``train()`` that loads a pretrained checkpoint
+and continues training with (typically lower) learning rate.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
-import os
-
-import torch
 
 from hsh.config import FinetuneConfig
-from hsh.data import make_dataloaders
-from hsh.train import load_checkpoint, save_checkpoint
+from hsh.train import train
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 log = logging.getLogger(__name__)
 
 
 def finetune(config: FinetuneConfig) -> dict:
-    """Finetune a model from a pretrained checkpoint.
+    """Finetune a model by resuming training from a checkpoint.
 
     Returns:
         Dict with final step, loss, and checkpoint path.
     """
-    torch.manual_seed(config.seed)
-
-    model, state = load_checkpoint(config.base_checkpoint)
-    model_config = model.config
-    start_step = state["step"]
-    log.info("Loaded checkpoint from step %d: %s", start_step, config.base_checkpoint)
-
-    optimizer = torch.optim.Adam(model.parameters(), lr=config.lr)
-
-    train_loader, _ = make_dataloaders(
-        batch_size=config.batch_size,
-        num_samples=config.num_samples,
-        input_dim=model_config.input_dim,
-        seed=config.seed,
-    )
-
-    os.makedirs(config.output_dir, exist_ok=True)
-
-    train_iter = iter(train_loader)
-    last_loss = float("nan")
-    last_ckpt_path = None
-
-    for step in range(start_step + 1, start_step + config.num_steps + 1):
-        model.train()
-        try:
-            batch = next(train_iter)
-        except StopIteration:
-            train_iter = iter(train_loader)
-            batch = next(train_iter)
-
-        loss = model.loss(batch["x0"], batch["x1"])
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-        last_loss = loss.item()
-
-        if step % max(config.num_steps // 5, 1) == 0:
-            log.info("finetune step=%d  loss=%.6f", step, last_loss)
-
-    last_ckpt_path = save_checkpoint(model, optimizer, step, model_config, config.output_dir)
-
-    return {"step": step, "loss": last_loss, "checkpoint": str(last_ckpt_path)}
+    return train(config.train, resume_from=config.base_checkpoint)
 
 
 def cli() -> None:
@@ -87,12 +39,14 @@ def cli() -> None:
 
     config = FinetuneConfig(
         base_checkpoint=args.base_checkpoint,
-        num_steps=args.num_steps,
-        lr=args.lr,
-        batch_size=args.batch_size,
-        num_samples=args.num_samples,
-        output_dir=args.output_dir,
-        seed=args.seed,
+        train=dict(
+            num_steps=args.num_steps,
+            lr=args.lr,
+            batch_size=args.batch_size,
+            num_samples=args.num_samples,
+            output_dir=args.output_dir,
+            seed=args.seed,
+        ),
     )
     result = finetune(config)
     log.info("Finetuning complete: %s", result)

--- a/src/hsh/train.py
+++ b/src/hsh/train.py
@@ -63,18 +63,33 @@ def load_checkpoint(
 def train(
     train_config: TrainConfig,
     model_config: ModelConfig | None = None,
+    resume_from: str | None = None,
 ) -> dict:
     """Run the training loop.
+
+    Args:
+        train_config: Training hyperparameters.
+        model_config: Architecture config (ignored when resuming).
+        resume_from: Path to checkpoint to resume from. When set,
+            model weights and step counter are loaded from the
+            checkpoint, and model_config is read from it.
 
     Returns:
         Dict with final step, loss, and checkpoint path.
     """
-    if model_config is None:
-        model_config = ModelConfig()
-
     torch.manual_seed(train_config.seed)
 
-    model = FlowMatchingMLP(model_config)
+    if resume_from is not None:
+        model, state = load_checkpoint(resume_from)
+        model_config = model.config
+        start_step = state["step"]
+        log.info("Resuming from checkpoint step %d: %s", start_step, resume_from)
+    else:
+        if model_config is None:
+            model_config = ModelConfig()
+        model = FlowMatchingMLP(model_config)
+        start_step = 0
+
     optimizer = torch.optim.Adam(model.parameters(), lr=train_config.lr)
     train_loader, val_loader = make_dataloaders(
         batch_size=train_config.batch_size,
@@ -89,7 +104,7 @@ def train(
     last_ckpt_path = None
     last_loss = float("nan")
 
-    for step in range(1, train_config.num_steps + 1):
+    for step in range(start_step + 1, start_step + train_config.num_steps + 1):
         model.train()
         try:
             batch = next(train_iter)

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -50,12 +50,16 @@ class TestPipelineE2E:
         ft_dir = tmp_path / "finetune"
         ft_config = FinetuneConfig(
             base_checkpoint=str(ckpt_path),
-            num_steps=2,
-            lr=1e-4,
-            batch_size=4,
-            num_samples=16,
-            output_dir=str(ft_dir),
-            seed=42,
+            train=TrainConfig(
+                num_steps=2,
+                lr=1e-4,
+                batch_size=4,
+                num_samples=16,
+                ckpt_every=2,
+                eval_every=2,
+                output_dir=str(ft_dir),
+                seed=42,
+            ),
         )
         ft_result = finetune(ft_config)
 


### PR DESCRIPTION
## Summary

- `FinetuneConfig` now composes `TrainConfig` instead of duplicating its fields
- `train()` accepts `resume_from` parameter to load a checkpoint and continue from its step count
- `finetune()` reduced to a thin one-line wrapper delegating to `train()`

**Evidence:** valence-labs/hooke-forge#12, hooke-forge uses `hooke-train --ckpt.resume_from`

## Test plan

- [x] All 14 existing tests pass
- [x] E2E test verifies train → finetune → eval → infer lifecycle
- [x] `ruff check` passes

Made with [Cursor](https://cursor.com)