### PR TITLE
feat: replace argparse with hydra-zen + Pydantic ConfigStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "MVP train/finetune/eval/infer pipeline for the Hooke ecosystem"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "hydra-core>=1.3",
+    "hydra-zen>=0.13",
     "pydantic>=2.0",
     "torch>=2.0",
 ]

--- a/src/hsh/eval.py
+++ b/src/hsh/eval.py
@@ -8,16 +8,17 @@ Mirrors hooke-forge's eval.py pattern:
 
 from __future__ import annotations
 
-import argparse
 import json
 import logging
 import os
 from pathlib import Path
 
 import torch
+from hydra_zen import store, zen
 
 from hsh.config import EvalConfig
 from hsh.data import make_dataloaders
+from hsh.hydra_conf import EvalTaskConf
 from hsh.train import load_checkpoint
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -68,21 +69,15 @@ def evaluate(config: EvalConfig) -> dict:
 
 
 def cli() -> None:
-    """CLI entry point for hsh-eval."""
-    parser = argparse.ArgumentParser(description="Evaluate a trained checkpoint")
-    parser.add_argument("--checkpoint", type=str, required=True)
-    parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--num-samples", type=int, default=64)
-    parser.add_argument("--output-dir", type=str, default="./eval_outputs")
-    args = parser.parse_args()
+    """CLI entry point for hsh-eval.
 
-    config = EvalConfig(
-        checkpoint=args.checkpoint,
-        batch_size=args.batch_size,
-        num_samples=args.num_samples,
-        output_dir=args.output_dir,
-    )
-    evaluate(config)
+    Override fields with Hydra's ``key=value`` syntax, e.g.::
+
+        hsh-eval config.checkpoint=path/to/ckpt config.batch_size=16
+    """
+    store(EvalTaskConf, name="hsh_eval")
+    store.add_to_hydra_store()
+    zen(evaluate).hydra_main(config_name="hsh_eval", version_base="1.3", config_path=None)
 
 
 if __name__ == "__main__":

--- a/src/hsh/finetune.py
+++ b/src/hsh/finetune.py
@@ -9,14 +9,15 @@ Mirrors hooke-forge's finetuning pattern:
 
 from __future__ import annotations
 
-import argparse
 import logging
 import os
 
 import torch
+from hydra_zen import store, zen
 
 from hsh.config import FinetuneConfig
 from hsh.data import make_dataloaders
+from hsh.hydra_conf import FinetuneTaskConf
 from hsh.train import load_checkpoint, save_checkpoint
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -74,28 +75,15 @@ def finetune(config: FinetuneConfig) -> dict:
 
 
 def cli() -> None:
-    """CLI entry point for hsh-finetune."""
-    parser = argparse.ArgumentParser(description="Finetune from a pretrained checkpoint")
-    parser.add_argument("--base-checkpoint", type=str, required=True)
-    parser.add_argument("--num-steps", type=int, default=50)
-    parser.add_argument("--lr", type=float, default=1e-4)
-    parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--num-samples", type=int, default=64)
-    parser.add_argument("--output-dir", type=str, default="./finetune_outputs")
-    parser.add_argument("--seed", type=int, default=42)
-    args = parser.parse_args()
+    """CLI entry point for hsh-finetune.
 
-    config = FinetuneConfig(
-        base_checkpoint=args.base_checkpoint,
-        num_steps=args.num_steps,
-        lr=args.lr,
-        batch_size=args.batch_size,
-        num_samples=args.num_samples,
-        output_dir=args.output_dir,
-        seed=args.seed,
-    )
-    result = finetune(config)
-    log.info("Finetuning complete: %s", result)
+    Override fields with Hydra's ``key=value`` syntax, e.g.::
+
+        hsh-finetune config.base_checkpoint=path/to/ckpt config.lr=5e-5
+    """
+    store(FinetuneTaskConf, name="hsh_finetune")
+    store.add_to_hydra_store()
+    zen(finetune).hydra_main(config_name="hsh_finetune", version_base="1.3", config_path=None)
 
 
 if __name__ == "__main__":

--- a/src/hsh/hydra_conf.py
+++ b/src/hsh/hydra_conf.py
@@ -1,0 +1,23 @@
+"""Register Pydantic configs with Hydra's ConfigStore via hydra-zen.
+
+No YAML files are produced or consumed.  ``builds()`` creates structured
+configs that carry ``_target_`` metadata so ``zen()`` can instantiate
+the original Pydantic types at runtime.
+"""
+
+from __future__ import annotations
+
+from hydra_zen import builds, make_config
+
+from hsh.config import EvalConfig, FinetuneConfig, InferConfig, ModelConfig, TrainConfig
+
+ModelConf = builds(ModelConfig, populate_full_signature=True)
+TrainConf = builds(TrainConfig, populate_full_signature=True)
+FinetuneConf = builds(FinetuneConfig, populate_full_signature=True)
+EvalConf = builds(EvalConfig, populate_full_signature=True)
+InferConf = builds(InferConfig, populate_full_signature=True)
+
+TrainTaskConf = make_config(train_config=TrainConf, model_config=ModelConf)
+FinetuneTaskConf = make_config(config=FinetuneConf)
+EvalTaskConf = make_config(config=EvalConf)
+InferTaskConf = make_config(config=InferConf)

--- a/src/hsh/infer.py
+++ b/src/hsh/infer.py
@@ -8,15 +8,16 @@ Mirrors hooke-forge's inference pattern:
 
 from __future__ import annotations
 
-import argparse
 import logging
 import os
 from pathlib import Path
 
 import torch
+from hydra_zen import store, zen
 
 from hsh.config import InferConfig
 from hsh.data import SyntheticDataset, collate_fn
+from hsh.hydra_conf import InferTaskConf
 from hsh.train import load_checkpoint
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -64,21 +65,15 @@ def infer(config: InferConfig) -> dict:
 
 
 def cli() -> None:
-    """CLI entry point for hsh-infer."""
-    parser = argparse.ArgumentParser(description="Run inference with a trained checkpoint")
-    parser.add_argument("--checkpoint", type=str, required=True)
-    parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--num-samples", type=int, default=32)
-    parser.add_argument("--output-dir", type=str, default="./predictions")
-    args = parser.parse_args()
+    """CLI entry point for hsh-infer.
 
-    config = InferConfig(
-        checkpoint=args.checkpoint,
-        batch_size=args.batch_size,
-        num_samples=args.num_samples,
-        output_dir=args.output_dir,
-    )
-    infer(config)
+    Override fields with Hydra's ``key=value`` syntax, e.g.::
+
+        hsh-infer config.checkpoint=path/to/ckpt config.num_samples=64
+    """
+    store(InferTaskConf, name="hsh_infer")
+    store.add_to_hydra_store()
+    zen(infer).hydra_main(config_name="hsh_infer", version_base="1.3", config_path=None)
 
 
 if __name__ == "__main__":

--- a/src/hsh/train.py
+++ b/src/hsh/train.py
@@ -8,16 +8,17 @@ Mirrors hooke-forge's trainer.py pattern:
 
 from __future__ import annotations
 
-import argparse
 import json
 import logging
 import os
 from pathlib import Path
 
 import torch
+from hydra_zen import store, zen
 
 from hsh.config import ModelConfig, TrainConfig
 from hsh.data import make_dataloaders
+from hsh.hydra_conf import TrainTaskConf
 from hsh.model import FlowMatchingMLP
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -127,30 +128,16 @@ def train(
 
 
 def cli() -> None:
-    """CLI entry point for hsh-train."""
-    parser = argparse.ArgumentParser(description="Train a minimal flow-matching model")
-    parser.add_argument("--num-steps", type=int, default=100)
-    parser.add_argument("--batch-size", type=int, default=8)
-    parser.add_argument("--lr", type=float, default=1e-3)
-    parser.add_argument("--num-samples", type=int, default=64)
-    parser.add_argument("--output-dir", type=str, default="./outputs")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--hidden-dim", type=int, default=64)
-    parser.add_argument("--num-layers", type=int, default=2)
-    parser.add_argument("--input-dim", type=int, default=32)
-    args = parser.parse_args()
+    """CLI entry point for hsh-train.
 
-    model_config = ModelConfig(input_dim=args.input_dim, hidden_dim=args.hidden_dim, num_layers=args.num_layers)
-    train_config = TrainConfig(
-        num_steps=args.num_steps,
-        batch_size=args.batch_size,
-        lr=args.lr,
-        num_samples=args.num_samples,
-        output_dir=args.output_dir,
-        seed=args.seed,
-    )
-    result = train(train_config, model_config)
-    log.info("Training complete: %s", result)
+    Uses hydra-zen to auto-generate CLI flags from Pydantic configs.
+    Override fields with Hydra's ``key=value`` syntax, e.g.::
+
+        hsh-train train_config.num_steps=200 model_config.hidden_dim=128
+    """
+    store(TrainTaskConf, name="hsh_train")
+    store.add_to_hydra_store()
+    zen(train).hydra_main(config_name="hsh_train", version_base="1.3", config_path=None)
 
 
 if __name__ == "__main__":

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -10,11 +10,15 @@ import pytest
 
 @pytest.mark.parametrize("command", ["hsh-train", "hsh-finetune", "hsh-eval", "hsh-infer"])
 def test_cli_help(command: str) -> None:
+    module = command.replace("hsh-", "")
     result = subprocess.run(
-        [sys.executable, "-m", f"hsh.{command.replace('hsh-', '')}",  "--help"],
+        [sys.executable, "-m", f"hsh.{module}", "--help"],
         capture_output=True,
         text=True,
         timeout=30,
     )
     assert result.returncode == 0, f"{command} --help failed:\n{result.stderr}"
-    assert "usage:" in result.stdout.lower() or "options:" in result.stdout.lower()
+    output = result.stdout.lower()
+    assert "config" in output or "override" in output, (
+        f"{command} --help did not show Hydra config output:\n{result.stdout}"
+    )


### PR DESCRIPTION
## Summary

- All 4 CLIs (`hsh-train`, `hsh-finetune`, `hsh-eval`, `hsh-infer`) now use hydra-zen's `zen()` wrapper instead of argparse
- New `src/hsh/hydra_conf.py` uses `builds()` to auto-generate Hydra structured configs from existing Pydantic models — zero manual `add_argument` duplication
- Added `hydra-core>=1.3` and `hydra-zen>=0.13` to dependencies
- Override fields with Hydra's `key=value` syntax: `hsh-train train_config.num_steps=200`

**Evidence:** ctr26/hooke-forge#40 (Hydra+Pydantic migration), valence-labs/hooke-forge#13 (config validation)

## Test plan

- [x] All 14 tests pass
- [x] CLI smoke tests verify `--help` output from Hydra
- [x] `ruff check` passes

Made with [Cursor](https://cursor.com)