### PR TITLE
refactor: move finetuning into separate uv workspace member

### DIFF
--- a/packages/hsh-finetune/pyproject.toml
+++ b/packages/hsh-finetune/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "hsh-finetune"
+version = "0.1.0"
+description = "Finetuning workspace member for the Hooke ecosystem"
+requires-python = ">=3.12"
+dependencies = [
+    "hsh",
+]
+
+[tool.uv.sources]
+hsh = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hsh_finetune"]
+
+[project.scripts]
+hsh-finetune = "hsh_finetune.finetune:cli"

--- a/packages/hsh-finetune/src/hsh_finetune/__init__.py
+++ b/packages/hsh-finetune/src/hsh_finetune/__init__.py
@@ -1,0 +1,3 @@
+"""hsh-finetune: finetuning workspace member for the Hooke ecosystem."""
+
+__version__ = "0.1.0"

--- a/packages/hsh-finetune/src/hsh_finetune/config.py
+++ b/packages/hsh-finetune/src/hsh_finetune/config.py
@@ -1,0 +1,24 @@
+"""Finetuning configuration.
+
+Kept in the hsh-finetune workspace member so it can be installed
+and versioned independently of the core hsh package.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from hsh.config import TrainConfig
+
+
+class FinetuneConfig(BaseModel, frozen=True):
+    """Finetuning config -- composes TrainConfig with a base checkpoint.
+
+    Finetuning reuses the pretraining loop; this config just adds
+    the checkpoint path and overrides training defaults.
+    """
+
+    base_checkpoint: str = Field(description="Path to pretrained checkpoint")
+    train: TrainConfig = Field(
+        default_factory=lambda: TrainConfig(num_steps=50, lr=1e-4, output_dir="./finetune_outputs")
+    )

--- a/packages/hsh-finetune/src/hsh_finetune/finetune.py
+++ b/packages/hsh-finetune/src/hsh_finetune/finetune.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import argparse
 import logging
 
-from hsh.config import FinetuneConfig
 from hsh.train import train
+from hsh_finetune.config import FinetuneConfig
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,10 @@ markers = [
     "slow: long-running test",
 ]
 
+[tool.uv.workspace]
+members = ["packages/*"]
+
 [project.scripts]
 hsh-train = "hsh.train:cli"
-hsh-finetune = "hsh.finetune:cli"
 hsh-eval = "hsh.eval:cli"
 hsh-infer = "hsh.infer:cli"

--- a/src/hsh/config.py
+++ b/src/hsh/config.py
@@ -30,19 +30,6 @@ class TrainConfig(BaseModel, frozen=True):
     seed: int = Field(default=42)
 
 
-class FinetuneConfig(BaseModel, frozen=True):
-    """Finetuning config -- composes TrainConfig with a base checkpoint.
-
-    Finetuning reuses the pretraining loop; this config just adds
-    the checkpoint path and overrides training defaults.
-    """
-
-    base_checkpoint: str = Field(description="Path to pretrained checkpoint")
-    train: TrainConfig = Field(
-        default_factory=lambda: TrainConfig(num_steps=50, lr=1e-4, output_dir="./finetune_outputs")
-    )
-
-
 class EvalConfig(BaseModel, frozen=True):
     """Evaluation config."""
 

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import torch
+from hsh_finetune.config import FinetuneConfig
+from hsh_finetune.finetune import finetune
 
-from hsh.config import EvalConfig, FinetuneConfig, InferConfig, ModelConfig, TrainConfig
+from hsh.config import EvalConfig, InferConfig, ModelConfig, TrainConfig
 from hsh.eval import evaluate
-from hsh.finetune import finetune
 from hsh.infer import infer
 from hsh.train import train
 

--- a/tests/smoke/test_cli.py
+++ b/tests/smoke/test_cli.py
@@ -7,11 +7,18 @@ import sys
 
 import pytest
 
+CLI_MODULES = [
+    ("hsh-train", "hsh.train"),
+    ("hsh-finetune", "hsh_finetune.finetune"),
+    ("hsh-eval", "hsh.eval"),
+    ("hsh-infer", "hsh.infer"),
+]
 
-@pytest.mark.parametrize("command", ["hsh-train", "hsh-finetune", "hsh-eval", "hsh-infer"])
-def test_cli_help(command: str) -> None:
+
+@pytest.mark.parametrize("command,module", CLI_MODULES, ids=[c for c, _ in CLI_MODULES])
+def test_cli_help(command: str, module: str) -> None:
     result = subprocess.run(
-        [sys.executable, "-m", f"hsh.{command.replace('hsh-', '')}",  "--help"],
+        [sys.executable, "-m", module, "--help"],
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/smoke/test_imports.py
+++ b/tests/smoke/test_imports.py
@@ -20,7 +20,7 @@ def test_import_train() -> None:
 
 
 def test_import_finetune() -> None:
-    from hsh.finetune import finetune
+    from hsh_finetune.finetune import finetune
 
     assert callable(finetune)
 
@@ -38,6 +38,8 @@ def test_import_infer() -> None:
 
 
 def test_import_configs() -> None:
-    from hsh.config import EvalConfig, FinetuneConfig, InferConfig, ModelConfig, TrainConfig
+    from hsh_finetune.config import FinetuneConfig
+
+    from hsh.config import EvalConfig, InferConfig, ModelConfig, TrainConfig
 
     assert all(callable(c) for c in [ModelConfig, TrainConfig, FinetuneConfig, EvalConfig, InferConfig])


### PR DESCRIPTION
## Summary

- `FinetuneConfig` and finetune logic moved to `packages/hsh-finetune/` as independently installable workspace member
- Root `pyproject.toml` declares `[tool.uv.workspace] members = ["packages/*"]`
- Workspace member depends on `hsh` via `[tool.uv.sources] hsh = { workspace = true }`
- All imports updated: `hsh.finetune` → `hsh_finetune.finetune`

**Evidence:** ctr26/hooke-forge#105 (workspace split), ctr26/hooke-forge#148 (monorepo with uv workspaces)

**Depends on:** ctr26/hooke#14 (finetune reuses trainer)

## Test plan

- [x] All 14 tests pass
- [x] `uv sync --all-packages --extra dev` resolves both workspace members
- [x] `ruff check` passes

Made with [Cursor](https://cursor.com)